### PR TITLE
docs(readme): bump aws-assume-role-with-web-identity plugin to v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ steps:
     command: "npm test"
     plugins:
       - bedrock-summarize#v1.0.0: ~
-      - aws-assume-role-with-web-identity#v1.4.0:
+      - aws-assume-role-with-web-identity#v1.6.0:
           role-arn: arn:aws:iam::12345:role/bedrock-access
 ```
 


### PR DESCRIPTION
## Summary

- Bumps the example snippet in `README.md` from `aws-assume-role-with-web-identity#v1.4.0` to `v1.6.0`, the [latest release](https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/tags) of the OIDC assume-role plugin
- README-only change; no plugin runtime behaviour is affected

## Changes between v1.4.0 and v1.6.0

- v1.5.0 — release/version bump preparing for v1.5
- v1.6.0 — `feat: unlink oidc and aws token lifetimes` (snorkel-ai/lifetimes, #44)

## Test plan

- [ ] CI passes (shellcheck, plugin-tester, plugin-linter)
- [ ] Visual review of README example renders correctly on GitHub
